### PR TITLE
Fix inactive icon color property

### DIFF
--- a/RecipeApp/Resources/Colors/ColorManager.swift
+++ b/RecipeApp/Resources/Colors/ColorManager.swift
@@ -26,8 +26,8 @@ struct ColorManager {
     /// TextSecondary color
     static let textSecondary = Color("TextSecondary")
     
-    /// InActiveIcon
-    static let inActiveIcon = Color("InActiveIcon")
+    /// Icon color used when a tab is inactive
+    static let inactiveIcon = Color("InActiveIcon")
         
     
     // MARK: - Dynamic Colors

--- a/RecipeApp/Views/Components/TabBar.swift
+++ b/RecipeApp/Views/Components/TabBar.swift
@@ -59,7 +59,7 @@ struct TabBar: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: 20, height: 20)
-                            .foregroundColor(item == selected ? ColorManager.primary : ColorManager.inActiveIcon)
+                            .foregroundColor(item == selected ? ColorManager.primary : ColorManager.inactiveIcon)
                         Spacer().frame(height: 8)
                     }
                 }


### PR DESCRIPTION
## Summary
- rename `inActiveIcon` to `inactiveIcon` in `ColorManager`
- update TabBar to use the renamed property

## Testing
- `No tests found`

------
https://chatgpt.com/codex/tasks/task_e_6840f8b1fd408324ae06cbb27b483c67